### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -137,7 +137,7 @@ Used to test if the user has entered a specific set of digits, eg:  @pressed_1?@
 
 h3. @not_(predicate)?@
 
-This form will invert the logic (convienient for trigger functions) of any method that your worklfow supports.  Eg: @not_pressed_1?@
+This form will invert the logic (convenient for trigger functions) of any method that your worklfow supports.  Eg: @not_pressed_1?@
 
 h3. @(state_name)_message@
 


### PR DESCRIPTION
@kyleburton, I've corrected a typographical error in the documentation of the [twilio-in-ten-minutes](https://github.com/kyleburton/twilio-in-ten-minutes) project. Specifically, I've changed convienient to convenient. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
